### PR TITLE
Fix sanitize_input overzealous filtering and add tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import unittest
+import sys
+import types
+
+# Provide minimal stubs for external modules used by utils
+if 'pandas' not in sys.modules:
+    sys.modules['pandas'] = types.SimpleNamespace(DataFrame=object)
+if 'pytz' not in sys.modules:
+    sys.modules['pytz'] = types.SimpleNamespace(timezone=lambda tz: tz)
+
+from utils import sanitize_input
+
+class TestUtils(unittest.TestCase):
+    def test_sanitize_input_preserves_punctuation(self):
+        text = "Hello, world: (test) 1+1=2"
+        self.assertEqual(sanitize_input(text), text)
+
+    def test_sanitize_input_removes_nonprintable(self):
+        text = "Hello\x00World"
+        self.assertEqual(sanitize_input(text), "HelloWorld")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -17,10 +17,10 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(level
 logger = logging.getLogger(__name__)
 
 def sanitize_input(input_str: str) -> str:
-    """
-    Sanitize input to prevent injection and adhere to OWASP standards.
-    """
-    sanitized = re.sub(r'[^\w\s,.!?@#%-]', '', input_str)
+    """Remove non-printable characters while preserving punctuation."""
+    sanitized = "".join(
+        ch for ch in input_str if ch.isprintable() or ch in "\n\r\t"
+    )
     logger.info(f"Input sanitized: {sanitized}")
     return sanitized
 


### PR DESCRIPTION
## Summary
- sanitize_input removed many valid characters which altered prompts
- relax sanitation to only drop non-printable characters
- add unit tests for sanitize_input

## Testing
- `python3 -m unittest discover -v`