### PR TITLE
Add document reader abstractions

### DIFF
--- a/app/docreader.py
+++ b/app/docreader.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import io
+from abc import ABC, abstractmethod
+from typing import Dict, Tuple, Any
+
+from .logger import logger
+from .file_processor import extract_text_from_pdf, extract_text_from_docx
+
+
+class DocReader(ABC):
+    """Base class for document readers.
+
+    Subclasses implement :meth:`load` and :meth:`parse` to return text and
+    metadata from various document formats.
+    """
+
+    @abstractmethod
+    def load(self, path: str) -> bytes:
+        """Load a document from disk.
+
+        Args:
+            path: Path to the document.
+
+        Returns:
+            Raw document bytes.
+        """
+
+    @abstractmethod
+    def parse(self, data: bytes, **kwargs: Any) -> Tuple[str, Dict[str, Any]]:
+        """Parse ``data`` and return text and metadata.
+
+        Args:
+            data: Document bytes.
+            **kwargs: Reader specific options.
+
+        Returns:
+            Tuple containing extracted text and metadata.
+        """
+
+    def read(self, path: str, **kwargs: Any) -> Tuple[str, Dict[str, Any]]:
+        """Load and parse a document in one call.
+
+        Args:
+            path: Path to the document.
+            **kwargs: Options forwarded to :meth:`parse`.
+
+        Returns:
+            Tuple of extracted text and metadata.
+        """
+        logger.debug(f"Reading document from {path}")
+        data = self.load(path)
+        return self.parse(data, **kwargs)
+
+
+class PDFDocReader(DocReader):
+    """Reader for PDF files based on :func:`extract_text_from_pdf`."""
+
+    def load(self, path: str) -> bytes:
+        """Load PDF bytes from ``path``.
+
+        Args:
+            path: Location of the PDF file.
+
+        Returns:
+            The file contents as bytes.
+        """
+        with open(path, "rb") as f:
+            return f.read()
+
+    def parse(self, data: bytes, *, extract_tables: bool = False, **_: Any) -> Tuple[str, Dict[str, Any]]:
+        """Parse PDF bytes.
+
+        Args:
+            data: PDF data.
+            extract_tables: Whether to parse tables in the PDF.
+
+        Returns:
+            Extracted text and metadata.
+        """
+        file_obj = io.BytesIO(data)
+        text, meta = extract_text_from_pdf(file_obj, extract_tables)
+        return text, meta
+
+
+class DOCXDocReader(DocReader):
+    """Reader for DOCX files based on :func:`extract_text_from_docx`."""
+
+    def load(self, path: str) -> bytes:
+        """Load DOCX bytes from ``path``.
+
+        Args:
+            path: Path to the DOCX file.
+
+        Returns:
+            The raw file contents.
+        """
+        with open(path, "rb") as f:
+            return f.read()
+
+    def parse(self, data: bytes, **_: Any) -> Tuple[str, Dict[str, Any]]:
+        """Parse DOCX bytes.
+
+        Args:
+            data: DOCX data.
+
+        Returns:
+            Extracted text and metadata.
+        """
+        file_obj = io.BytesIO(data)
+        text, meta = extract_text_from_docx(file_obj)
+        return text, meta
+
+
+__all__ = ["DocReader", "PDFDocReader", "DOCXDocReader"]

--- a/app/logger.py
+++ b/app/logger.py
@@ -35,3 +35,5 @@ def setup_logger(log_dir: str = "logs") -> None:
         filter=lambda record: record["level"].name == "ERROR",
     )
 
+
+__all__ = ["setup_logger", "logger"]

--- a/app/orchestrator.py
+++ b/app/orchestrator.py
@@ -1,47 +1,87 @@
-import asyncio
 from typing import List, Dict
 
 from .openai_client import AsyncOpenAIClient
 from .tokenizer import Tokenizer
-from .pdfreader.pdf_loader import chunk_pdf
+
+from .docreader import DocReader, PDFDocReader
 from .prompt_store import PromptStore
 from .postprocessor import merge_chunks
 from .logger import logger
 
 
 class Orchestrator:
-    """Coordinate PDF loading, chunking and OpenAI requests."""
+    """Coordinate document loading, chunking and OpenAI requests."""
 
     def __init__(
         self,
         client: AsyncOpenAIClient,
         tokenizer: Tokenizer,
         store: PromptStore,
+        reader: DocReader,
     ) -> None:
+        """Instantiate the orchestrator.
+
+        Args:
+            client: OpenAI client used for completion requests.
+            tokenizer: Tokenizer used for chunking documents.
+            store: Storage backend for prompts and responses.
+            reader: Document reader implementation.
+        """
         self.client = client
         self.tokenizer = tokenizer
         self.store = store
+        self.reader = reader
 
-    async def process_pdf(self, path: str, **kwargs) -> str:
-        logger.info(f"Starting PDF processing for {path}")
-        _text, chunks, digest = chunk_pdf(path, self.tokenizer, **kwargs)
-        logger.info(f"PDF {path} split into {len(chunks)} chunks")
+    async def process_document(self, path: str, **kwargs) -> str:
+        """Process a document.
+
+        Args:
+            path: Path to the document to process.
+            **kwargs: Additional options such as ``max_tokens`` or ``overlap``.
+
+        Returns:
+            Combined response from the LLM for the entire document.
+        """
+        logger.info(f"Starting processing for {path}")
+        text, _ = self.reader.read(path, **kwargs)
+        chunks = self.tokenizer.chunk(
+            text,
+            max_tokens=kwargs.get("max_tokens", 2000),
+            overlap=kwargs.get("overlap", 50),
+        )
+        logger.info(f"{path} split into {len(chunks)} chunks")
         responses: List[Dict] = []
         for chunk in chunks:
             resp = await self.client.chat_complete([
                 {"role": "user", "content": chunk}
-            ], max_tokens=kwargs.get("max_tokens", 500))
+            ], max_tokens=kwargs.get("response_tokens", 500))
             responses.append(resp)
             self.store.save(chunk, resp)
-        logger.info(f"Completed PDF processing for {path}")
+        logger.info(f"Completed processing for {path}")
         return merge_chunks(responses)
+
+    async def process_pdf(self, path: str, **kwargs) -> str:
+        """Backward compatible PDF processing."""
+        return await self.process_document(path, **kwargs)
 
 
 async def run_pdf(path: str, model: str = "gpt-3.5-turbo", budget: float = None, output: str = None) -> str:
+    """Helper to process a PDF without constructing an :class:`Orchestrator`.
+
+    Args:
+        path: Path to the PDF file.
+        model: OpenAI model name.
+        budget: Optional spending limit for API usage.
+        output: Optional path to save responses.
+
+    Returns:
+        The aggregated LLM response for the PDF.
+    """
     logger.info(f"run_pdf called with path={path} model={model} budget={budget}")
     tokenizer = Tokenizer(model)
     client = AsyncOpenAIClient(model=model, budget=budget)
     store = PromptStore(output or "store.jsonl")
-    orchestrator = Orchestrator(client, tokenizer, store)
-    result = await orchestrator.process_pdf(path)
+    reader = PDFDocReader()
+    orchestrator = Orchestrator(client, tokenizer, store, reader)
+    result = await orchestrator.process_document(path)
     return result


### PR DESCRIPTION
## Summary
- implement `DocReader`, `PDFDocReader`, and `DOCXDocReader`
- refactor `Orchestrator` to use the new readers
- export `logger` in `app.logger`
- document reader classes and orchestrator methods with Google-style docstrings

## Testing
- `mypy --strict app/batch_manager.py app/openai_batch.py app/file_processor.py app/utils.py streamlit/app.py`
- `pytest -q`
