### PR TITLE
Refactor pdf reader location

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ python cli.py s3://my-bucket/prompts.txt --redact
   - `file_processor.py` - File processing utilities
   - `utils.py` - Helper utilities
   - `tokenizer.py` - Token counting and chunking
-  - `pdfreader/pdf_loader.py` - PDF helpers
+  - `pdfreader.py` - PDF helpers
   - `prompt_store.py` - Prompt loading utilities
   - `postprocessor.py` - Combine chunked responses
   - `wowrunner.py` - High level batch runner

--- a/app/pdfreader.py
+++ b/app/pdfreader.py
@@ -6,8 +6,8 @@ from typing import List, Tuple
 
 import pdfplumber
 
-from ..tokenizer import Tokenizer
-from ..logger import logger
+from .tokenizer import Tokenizer
+from .logger import logger
 
 
 def load_pdf(path: str) -> Tuple[str, str]:


### PR DESCRIPTION
## Summary
- move `pdfreader/pdf_loader.py` to `pdfreader.py`
- document new `pdfreader.py` location in README

## Testing
- `pytest -q`
